### PR TITLE
Set color of buttons based on theme

### DIFF
--- a/android/core/src/main/kotlin/com/masilotti/bridgecomponents/BridgeComponents.kt
+++ b/android/core/src/main/kotlin/com/masilotti/bridgecomponents/BridgeComponents.kt
@@ -1,5 +1,10 @@
 package com.masilotti.bridgecomponents
 
+ import androidx.annotation.ColorInt
+ import androidx.appcompat.widget.Toolbar
+ import androidx.compose.ui.graphics.Color
+ import com.google.android.material.R
+ import com.google.android.material.color.MaterialColors
  import com.masilotti.bridgecomponents.alert.AlertComponent
  import com.masilotti.bridgecomponents.button.ButtonComponent
  import com.masilotti.bridgecomponents.form.FormComponent
@@ -25,4 +30,10 @@ object BridgeComponents {
          BridgeComponentFactory("theme", ::ThemeComponent),
          BridgeComponentFactory("toast", ::ToastComponent),
      ).toTypedArray()
+}
+
+@ColorInt
+fun colorOnSurface(view: Toolbar): Color {
+    val white = 0xFFFFFFFF.toInt()
+    return Color(MaterialColors.getColor(view, R.attr.colorOnSurface, white))
 }

--- a/android/core/src/main/kotlin/com/masilotti/bridgecomponents/button/ButtonComponent.kt
+++ b/android/core/src/main/kotlin/com/masilotti/bridgecomponents/button/ButtonComponent.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.sp
 import com.masilotti.bridgecomponents.R
+import com.masilotti.bridgecomponents.colorOnSurface
 import dev.hotwire.core.bridge.BridgeComponent
 import dev.hotwire.core.bridge.BridgeDelegate
 import dev.hotwire.core.bridge.Message
@@ -42,6 +43,7 @@ class ButtonComponent(
 
     private fun addButton(message: Message) {
         val data = message.data<MessageData>() ?: return
+        val toolbar = fragment.toolbarForNavigation() ?: return
         removeButton()
 
         val composeView = ComposeView(fragment.requireContext()).apply {
@@ -50,6 +52,7 @@ class ButtonComponent(
                 ToolbarButton(
                     title = data.title,
                     imageName = data.imageName,
+                    contentColor = colorOnSurface(toolbar),
                     onClick = { replyTo(message.event) })
             }
         }
@@ -58,8 +61,7 @@ class ButtonComponent(
             ViewGroup.LayoutParams.WRAP_CONTENT
         ).apply { gravity = Gravity.END }
 
-        val toolbar = fragment.toolbarForNavigation()
-        toolbar?.addView(composeView, layoutParams)
+        toolbar.addView(composeView, layoutParams)
     }
 
     private fun removeButton() {
@@ -76,12 +78,12 @@ class ButtonComponent(
 }
 
 @Composable
-private fun ToolbarButton(title: String, imageName: String?, onClick: () -> Unit) {
+private fun ToolbarButton(title: String, imageName: String?, contentColor: Color, onClick: () -> Unit) {
     Button(
         onClick = onClick,
         colors = ButtonDefaults.buttonColors(
             containerColor = Color.Transparent,
-            contentColor = Color.Black
+            contentColor = contentColor
         )
     ) {
         imageName?.let {

--- a/android/core/src/main/kotlin/com/masilotti/bridgecomponents/form/FormComponent.kt
+++ b/android/core/src/main/kotlin/com/masilotti/bridgecomponents/form/FormComponent.kt
@@ -14,6 +14,7 @@
  import androidx.compose.ui.graphics.Color
  import androidx.compose.ui.platform.ComposeView
  import androidx.compose.ui.platform.ViewCompositionStrategy
+ import com.masilotti.bridgecomponents.colorOnSurface
  import dev.hotwire.core.bridge.BridgeComponent
  import dev.hotwire.core.bridge.BridgeDelegate
  import dev.hotwire.core.bridge.Message
@@ -42,6 +43,7 @@
 
      private fun addButton(message: Message) {
          val data = message.data<MessageData>() ?: return
+         val toolbar = fragment.toolbarForNavigation() ?: return
          removeButton()
 
          val composeView = ComposeView(fragment.requireContext()).apply {
@@ -54,6 +56,7 @@
                  SubmitButton(
                      title = data.title,
                      enabled = enabledState.value,
+                     contentColor = colorOnSurface(toolbar),
                      onClick = { replyTo(message.event) }
                  )
              }
@@ -63,8 +66,7 @@
              ViewGroup.LayoutParams.WRAP_CONTENT
          ).apply { gravity = Gravity.END }
 
-         val toolbar = fragment.toolbarForNavigation()
-         toolbar?.addView(composeView, layoutParams)
+         toolbar.addView(composeView, layoutParams)
      }
 
      private fun removeButton() {
@@ -88,14 +90,14 @@
  }
 
  @Composable
- private fun SubmitButton(
-     title: String, enabled: Boolean, onClick: () -> Unit
- ) {
+ private fun SubmitButton(title: String, enabled: Boolean, contentColor: Color, onClick: () -> Unit) {
      Button(
          onClick = onClick,
          enabled = enabled,
          colors = ButtonDefaults.buttonColors(
-             containerColor = Color.Transparent, contentColor = Color.Black
+             containerColor = Color.Transparent,
+             contentColor = contentColor,
+             disabledContentColor = contentColor.copy(0.6f)
          )
      ) {
          Text(title)

--- a/android/core/src/main/kotlin/com/masilotti/bridgecomponents/share/ShareComponent.kt
+++ b/android/core/src/main/kotlin/com/masilotti/bridgecomponents/share/ShareComponent.kt
@@ -16,6 +16,7 @@
  import androidx.compose.ui.text.font.FontFamily
  import androidx.compose.ui.unit.sp
  import com.masilotti.bridgecomponents.R
+ import com.masilotti.bridgecomponents.colorOnSurface
  import dev.hotwire.core.bridge.BridgeComponent
  import dev.hotwire.core.bridge.BridgeDelegate
  import dev.hotwire.core.bridge.Message
@@ -40,13 +41,15 @@
      }
 
      private fun addButton(message: Message) {
-         removeButton()
          val data = message.data<MessageData>() ?: return
+         val toolbar = fragment.toolbarForNavigation() ?: return
+         removeButton()
 
          val composeView = ComposeView(fragment.requireContext()).apply {
              id = buttonId
              setContent {
                  ToolbarButton(
+                     contentColor = colorOnSurface(toolbar),
                      onClick = { share(data.url) })
              }
          }
@@ -55,8 +58,7 @@
              ViewGroup.LayoutParams.WRAP_CONTENT
          ).apply { gravity = Gravity.END }
 
-         val toolbar = fragment.toolbarForNavigation()
-         toolbar?.addView(composeView, layoutParams)
+         toolbar.addView(composeView, layoutParams)
      }
 
      private fun removeButton() {
@@ -80,12 +82,12 @@
  }
 
  @Composable
- private fun ToolbarButton(onClick: () -> Unit) {
+ private fun ToolbarButton(contentColor: Color, onClick: () -> Unit) {
      Button(
          onClick = onClick,
          colors = ButtonDefaults.buttonColors(
              containerColor = Color.Transparent,
-             contentColor = Color.Black
+             contentColor = contentColor
          )
      ) {
          Text(


### PR DESCRIPTION
Sets the color of `Toolbar` buttons based on the theme. Fixes an issue where buttons would be very hard to see when using a dark themed `Toolbar`.

Fixes #39.