### PR TITLE
Fix button component not removing bar button on disconnect

### DIFF
--- a/ios/components/ButtonComponent.swift
+++ b/ios/components/ButtonComponent.swift
@@ -10,6 +10,8 @@ public final class ButtonComponent: BridgeComponent {
         switch event {
         case .left, .right:
             addButton(via: message, side: event)
+        case .disconnect:
+            removeButton()
         }
     }
 
@@ -29,7 +31,15 @@ public final class ButtonComponent: BridgeComponent {
             viewController?.navigationItem.leftBarButtonItem = item
         case .right:
             viewController?.navigationItem.rightBarButtonItem = item
+        default:
+            return
         }
+    }
+    
+    private func removeButton() {
+        guard let navItem = viewController?.navigationItem else { return }
+        navItem.leftBarButtonItem = nil
+        navItem.rightBarButtonItem = nil
     }
 }
 
@@ -37,6 +47,7 @@ private extension ButtonComponent {
     enum Event: String {
         case left
         case right
+        case disconnect
     }
 }
 


### PR DESCRIPTION
### Problem
When signing out, the native navigation bar button for the ButtonComponent was not removed. 
Even though the web page refreshed, the native component remained, and tapping it did nothing.

### Solution
Move the button removal logic to respond to the Stimulus controller disconnect event.
Now, when the controller disconnects (such as on sign out), a "disconnect" message is sent 
to the native app, and the ButtonComponent correctly removes the bar button.

### Changes
- Added handling for `disconnect` event in ButtonComponent
- `removeButton()` clears left and right UIBarButtonItems
- Ensures the native button is always removed when the Stimulus controller disconnects

#### Before
[![Before](https://github.com/user-attachments/assets/4a3f0e52-829f-474c-b1e4-a4b6e455362c)](https://github.com/user-attachments/assets/4a3f0e52-829f-474c-b1e4-a4b6e455362c)

#### After
[![After](https://github.com/user-attachments/assets/3ed0f167-1bf1-4200-b7c7-24fb69a5e064)](https://github.com/user-attachments/assets/3ed0f167-1bf1-4200-b7c7-24fb69a5e064)

### Verification
- Sign in -> button appears
- Sign out -> button disappears
- Tapping the button after sign out does nothing